### PR TITLE
Includes user's email in profile if returned from facebook API

### DIFF
--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -254,7 +254,7 @@ function Facebookbot(configuration) {
                         first_name: identity.first_name,
                         last_name: identity.last_name,
                         full_name: identity.first_name + ' ' + identity.last_name,
-                        email: null, // no source for this info
+                        email: identity.email || null,
                         gender: identity.gender,
                         timezone_offset: identity.timezone,
                     };
@@ -765,7 +765,7 @@ function Facebookbot(configuration) {
 
     var user_profile = function(uid, fields, cb) {
         if (!fields) {
-            fields = 'first_name,last_name,timezone,gender,locale';
+            fields = 'first_name,last_name,timezone,gender,locale,email';
         }
         return new Promise(function(resolve, reject) {
             var uri = 'https://' + api_host + '/v2.6/' + uid + '?fields=' + fields + '&access_token=' + configuration.access_token;


### PR DESCRIPTION
If the Facebook profile API returns the user's email address, which it does for Workplace integrations, the Botkit profile should include it.